### PR TITLE
remove erroring code

### DIFF
--- a/snapshot_queries/query.py
+++ b/snapshot_queries/query.py
@@ -69,7 +69,7 @@ class Query:
             duration=TimeDelta(seconds=(stop_time - start_time)),
             idx=idx,
             is_select=sql.lower().strip().startswith("select"),
-            location=last_executed_line.location(),
+            location="",
             params=params,
             raw_params=raw_params,
             sql=sql,

--- a/snapshot_queries/testing/assert_queries_match_mixin.py
+++ b/snapshot_queries/testing/assert_queries_match_mixin.py
@@ -53,8 +53,7 @@ class AssertQueriesMatchMixin:
         two_newlines = "\n\n"
         try:
             return self.assert_match_snapshot(
-                f"\n{len(formatted_queries)} Queries{two_newlines}{two_newlines.join(formatted_queries)}\n",
-                name=name,
+                f"\n{len(formatted_queries)} Queries{two_newlines}{two_newlines.join(formatted_queries)}\n"
             )
         except AssertionError:
             # Catch the error and make the error more useful


### PR DESCRIPTION
The name parameter is only accepted in newer versions of snapshottest. If we upgrade our snapshottest it would be still ok because it has a default value.

Removed location because it causes the same error as in this issue: https://github.com/cedar-team/snapshot-queries/issues/32